### PR TITLE
Change serial to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Or via command-line:
 docker run -d \
   --device /sys/bus/usb/devices/<your-device-id> \
   --privileged \
-  -e SERIAL=<your-serial>
+  -e MATCH=<your-serial>
   -e PUMPSPEED=<your-pumpspeed>
   -e FANSPEED=<your-fanspeed>
   --restart=unless-stopped avpnusr/liquidctl

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,11 @@
 #! /bin/bash
 liquidctl initialize all
-liquidctl --serial $SERIAL list
-liquidctl --serial $SERIAL set pump speed $PUMPSPEED
-liquidctl --serial $SERIAL set fan speed $FANSPEED
+liquidctl --match $MATCH list
+liquidctl --match $MATCH set pump speed $PUMPSPEED
+liquidctl --match $MATCH set fan speed $FANSPEED
 sleep 20
 while true; do
-        liquidctl --serial $SERIAL status
+        liquidctl --match $MATCH status
         sleep 15
 done
 


### PR DESCRIPTION
Some devices don't have a serial #.  Match should support a serial or a name
```
Device #0: Corsair Hydro H115i Pro XT (experimental)
├── Vendor ID: 0x1b1c
├── Product ID: 0x0c21
├── Release number: 0x0100
├── Bus: hid
├── Address: /dev/hidraw0
└── Driver: HydroPlatinum
```